### PR TITLE
bug: unmatching date value & action handled within alert is not being executed

### DIFF
--- a/src/components/Calendar/Day/DayHeader.tsx
+++ b/src/components/Calendar/Day/DayHeader.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import { Dayjs } from 'dayjs';
 
-import { dateToday, getDateValues, stringifyDate } from '../../../util/calendar-arrangement';
+import { dateToday, getDateValues, convertDateUnitsToString } from '../../../util/calendar-arrangement';
 import { DateUnits } from '../../../context/global/index.model';
 import GlobalContext from '../../../context/global/GlobalContext';
 import GlobalContextInterface from '../../../context/global/index.model';
@@ -26,12 +26,12 @@ export default function DayHeader(props: DayHeaderProps) {
 	} = useContext(GlobalContext) as GlobalContextInterface;
 	const { dateObj, dayIndex, isCentered = true } = props;
 
-	const filteredSchedulesByDayAndTime = filteredSchedules.filter(sch => {
-		return sch.dateTime.date === stringifyDate(getDateValues(dateObj, {
+	const filteredSchedulesByDayAndTime = filteredSchedules.filter(schedule => {
+		return schedule.dateTime.date === convertDateUnitsToString(getDateValues(dateObj, {
 			yearFormat: 'YYYY',
 			monthFormat: 'MM',
 			dayFormat: 'DD',
-		})) && (sch.dateTime.time.start < 0 && sch.dateTime.time.end < 0 );
+		})) && (schedule.dateTime.time.start < 0 && schedule.dateTime.time.end < 0 );
 	});
 	
 	const areDatesEqual = (dateObjToCompare: DateUnits) => {

--- a/src/components/Calendar/Slot/Slot.tsx
+++ b/src/components/Calendar/Slot/Slot.tsx
@@ -52,7 +52,7 @@ export default function Slot(props: SlotProps) {
 		isScheduleViewVisible,
 		setIsScheduleViewVisible,
 		linkRef,
-	] = useComponentVisible(false);
+	] = useComponentVisible();
 	const scheduleViewProps = {
 		isDraggable: false,
 		isSelfAdjustable: true,

--- a/src/components/Calendar/Time/TimeBlockCol.tsx
+++ b/src/components/Calendar/Time/TimeBlockCol.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../../util/calendar-arrangement';
 import GlobalContext from '../../../context/global/GlobalContext';
 import GlobalContextInterface from '../../../context/global/index.model';
-import { stringifyDate } from '../../../util/calendar-arrangement';
+import { convertDateUnitsToString } from '../../../util/calendar-arrangement';
 
 import TimeRow from './TimeRow'
 
@@ -32,11 +32,11 @@ export default function TimeBlockCol(props: TimeBlockColProps) {
 		monthFormat: 'MM',
 		dayFormat: 'DD',
 	}
-	const stringifiedDate = stringifyDate(getDateValues(dateObj, defaultDateFormat));
+	const stringifiedDate = convertDateUnitsToString(getDateValues(dateObj, defaultDateFormat));
 	// Filter the available schedules by day index
 	const filteredSchedulesByDay = filteredSchedules.filter(schedule => {
 		const { start, end } = schedule.dateTime.time;
-		const stringifiedPrevDate = stringifyDate(getDateValues(dayjsObjByDay({
+		const stringifiedPrevDate = convertDateUnitsToString(getDateValues(dayjsObjByDay({
 			date: getDateValues(dateObj, defaultDateFormat),
 			calendarType: 'day',
 			index: -1,
@@ -60,7 +60,7 @@ export default function TimeBlockCol(props: TimeBlockColProps) {
 					const { start, end } = schedule.dateTime.time;
 					const timeIndex = type === 'task' ? end : start;
 					const isScheduleSetFromPrevDay = schedule.dateTime.date
-					!== stringifyDate(getDateValues(dateObj, defaultDateFormat));
+					!== convertDateUnitsToString(getDateValues(dateObj, defaultDateFormat));
 					const isIndexZero = hourIndex === 0;
 					const matchedHourRange =
 						!isScheduleSetFromPrevDay

--- a/src/components/Calendar/Time/TimeRow.tsx
+++ b/src/components/Calendar/Time/TimeRow.tsx
@@ -3,7 +3,7 @@ import GlobalContext from '../../../context/global/GlobalContext';
 import GlobalContextInterface, {
 	DateUnits, ScheduleTypes,
 } from '../../../context/global/index.model';
-import { stringifyDate } from '../../../util/calendar-arrangement';
+import { convertDateUnitsToString } from '../../../util/calendar-arrangement';
 import '../styles.scss';
 import Slot from '../Slot/Slot';
 
@@ -43,7 +43,7 @@ export default function TimeRow(props: TimeRowProps) {
 					recordPos(e);
 					setSelectedDate(dateValues);
 					setDefaultDateTime({
-						date: stringifyDate(dateValues),
+						date: convertDateUnitsToString(dateValues),
 						time: {
 							start: hourIndex,
 							end: (hourIndex + 1),
@@ -56,7 +56,7 @@ export default function TimeRow(props: TimeRowProps) {
 					filteredSchedulesByTime.map((schedule) => {
 						return <Slot
 							key={`slot-${schedule.id}`}
-							stringifiedDate={stringifyDate(dateValues)}
+							stringifiedDate={convertDateUnitsToString(dateValues)}
 							scheduleProps={schedule}
 						/>
 					})

--- a/src/components/Calendar/Time/TimeRowUnset.tsx
+++ b/src/components/Calendar/Time/TimeRowUnset.tsx
@@ -4,7 +4,7 @@ import GlobalContextInterface, {
 	DateUnits,
 	ScheduleTypes,
 } from '../../../context/global/index.model';
-import { stringifyDate } from '../../../util/calendar-arrangement';
+import { convertDateUnitsToString } from '../../../util/calendar-arrangement';
 import useComponentVisible from '../../../hooks/useComponentVisible';
 
 import '../styles.scss';
@@ -32,7 +32,7 @@ function SlotList(props: SlotListProps) {
 					if (index === 0) return;
 					return <Slot
 						key={`slot-list-item-${index}`}
-						stringifiedDate={stringifyDate(dateValues)}
+						stringifiedDate={convertDateUnitsToString(dateValues)}
 						scheduleProps={schedule}
 						scheduleViewPosition='absolute'
 					/>
@@ -60,7 +60,7 @@ export default function TimeRowUnset(props: TimeRowProps) {
 		isSlotListVisible,
 		setIsSlotListVisible,
 		linkRef,
-	] = useComponentVisible(false);
+	] = useComponentVisible();
 
 	const slotListProps = {
 		isDraggable: false,
@@ -87,7 +87,7 @@ export default function TimeRowUnset(props: TimeRowProps) {
 					recordPos(e);
 					setSelectedDate(dateValues);
 					setDefaultDateTime({
-						date: stringifyDate(dateValues),
+						date: convertDateUnitsToString(dateValues),
 						time: { start: -1, end: -1 },
 					});
 					setIsScheduleDialogVisible(true);
@@ -98,7 +98,7 @@ export default function TimeRowUnset(props: TimeRowProps) {
 						if (index !== 0) return;
 						return <Slot
 							key={`slot-${schedule.id}`}
-							stringifiedDate={stringifyDate(dateValues)}
+							stringifiedDate={convertDateUnitsToString(dateValues)}
 							scheduleProps={schedule}
 						/>
 					})

--- a/src/components/CalendarList/CalendarItem.tsx
+++ b/src/components/CalendarList/CalendarItem.tsx
@@ -14,7 +14,7 @@ import Dialog from '../../lib/Dialog';
 import Options from './Options';
 import { createPortal } from 'react-dom';
 
-export default function Label(props: LabelProps): JSX.Element {
+export default function CalendarItem(props: LabelProps): JSX.Element {
 	const { recordPos } = useContext(GlobalContext) as GlobalContextInterface;
 	const { calendarProps, globalContextProps } = props;
 	const { dispatchCalendarList } = globalContextProps;
@@ -26,14 +26,14 @@ export default function Label(props: LabelProps): JSX.Element {
 		isAlertVisible,
 		setIsAlertVisible,
 		alertLinkRef,
-	] = useComponentVisible(false);
+	] = useComponentVisible();
 
 	const [
 		dialogRef,
 		isCalendarLblOptsVisible,
 		setIsCalendarLblOptsVisible,
 		dialogLinkRef,
-	] = useComponentVisible(false);
+	] = useComponentVisible();
 
 	const handleToggleCbox = (e: React.ChangeEvent<HTMLInputElement>) => {
 		e.stopPropagation();
@@ -46,7 +46,7 @@ export default function Label(props: LabelProps): JSX.Element {
 		})
 	};
 
-	const removeCalendar = () => {
+	const deleteCalendar = () => {
 		dispatchCalendarList({ type: UserActionType.REMOVE, payload: id });
 		setIsAlertVisible(false);
 	};
@@ -119,9 +119,9 @@ export default function Label(props: LabelProps): JSX.Element {
 					<Alert
 						ref={alertRef}
 						name={`${name}'s `}
-						action='remove'
+						action='delete'
 						type='Calendar'
-						handleAction={removeCalendar}
+						handleAction={deleteCalendar}
 						handleHideComponent={() => setIsAlertVisible(false)}
 						isVisible={isAlertVisible}
 					/>,

--- a/src/components/CalendarList/CalendarItemList.tsx
+++ b/src/components/CalendarList/CalendarItemList.tsx
@@ -1,15 +1,15 @@
 import { CalendarLabelType } from '../../context/global/index.model';
 import { LabelListProps } from './index.model';
-import Label from './Label';
+import CalendarItem from './CalendarItem';
 
-export const LabelList = (props: LabelListProps): JSX.Element => {
+export const CalendarItemList = (props: LabelListProps): JSX.Element => {
 	const { calendarList } = props;
 	return <>{calendarList.map((calendarLbl: CalendarLabelType, index: number) => {
-		return <Label
-			key={`label-${index}`}
+		return <CalendarItem
+			key={`calendar-item-${index}`}
 			calendarProps={calendarLbl}
 			globalContextProps={props} />
 	})}</>
 }
 
-export default LabelList;
+export default CalendarItemList;

--- a/src/components/CalendarList/CalendarList.tsx
+++ b/src/components/CalendarList/CalendarList.tsx
@@ -14,7 +14,7 @@ import ChevronUp from '../../assets/icons/chevron-up.png';
 import PlusIcon from '../../assets/icons/plus.png';
 
 import NewCalendar from './NewCalendar';
-import LabelList from './LabelList';
+import CalendarItemList from './CalendarItemList';
 
 export default function CalendarList(): JSX.Element {
 	const { 
@@ -83,7 +83,7 @@ export default function CalendarList(): JSX.Element {
 					</span>
 				</div>
 				<ul className={`accordion__panel ${isCollapsed ? 'show' : 'hide'}`}>
-					<LabelList
+					<CalendarItemList
 						calendarList={calendarList}
 						dispatchCalendarList={dispatchCalendarList}
 						recordPos={recordPos}

--- a/src/components/CalendarList/NewCalendar.tsx
+++ b/src/components/CalendarList/NewCalendar.tsx
@@ -38,7 +38,7 @@ export default function NewCalendar(props: AddNewCalendarProps) {
 		isDialogVisible,
 		setIsDialogVisible,
 		dialogLinkRef,
-	] = useComponentVisible(false);
+	] = useComponentVisible();
 
 	const addCalendar = () => {
 		dispatchCalendarList({

--- a/src/components/Schedules/Dialog/DateTimeBlock.tsx
+++ b/src/components/Schedules/Dialog/DateTimeBlock.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 import GlobalContext from '../../../context/global/GlobalContext';
 import GlobalContextInterface, {
 	DateTimeInputs, DateUnits,
@@ -17,6 +17,7 @@ import MiniCalendar from '../../MiniCalendar';
 import Dialog from '../../../lib/Dialog';
 import CustomSelect from './CustomInputs/CustomSelect';
 import { Option } from '../index.model';
+import { convertStringToDateUnits } from '../../../util/calendar-arrangement';
 
 export interface DateTimeBlockProps {
 	dateTime: DateTimeInputs;
@@ -44,11 +45,23 @@ export default function DateTimeBlock(props: DateTimeBlockProps) {
 		linkRef,
 	] = useComponentVisible(false);
 
+	// The purpose of this is to prevent date change after its first
+	// execution so that existing schedule date won't overwritten
+	// by the highlighted date
+const dateChangeNotAllowed = useRef(true);
 	useEffect(() => {
-		handleDateChange(selectedDate);
+		if (dateChangeNotAllowed.current) {
+			dateChangeNotAllowed.current = false
+		} else {
+			handleDateChange(selectedDate);
+		}
 	}, [selectedDate])
+
 	const miniCalendarProps = {
 		Component: MiniCalendar,
+		componentProps: {
+			initialDate: convertStringToDateUnits(dateTime.date),
+		},
 		positionOffset: { x: 0, y: 30 },
 		isDraggable: false,
 		isDialogVisible: isMiniCalendarVisible,
@@ -57,7 +70,8 @@ export default function DateTimeBlock(props: DateTimeBlockProps) {
 	}
 
 	const dateToDisplay = () => {
-		return getShortDate(dayjsObj(selectedDate));
+		const dateToDisplay = convertStringToDateUnits(dateTime.date) || selectedDate;
+		return getShortDate(dayjsObj(dateToDisplay));
 	}
 
 	const options = scheduleTimeOptions.map(({ time }, hourIndex) => {
@@ -82,7 +96,6 @@ export default function DateTimeBlock(props: DateTimeBlockProps) {
 			}}
 		/>
 	}
-
 	return (
 		<>
 			<div className='schedule-input-list flex-centered'>

--- a/src/components/Schedules/Dialog/DescInputBlock.tsx
+++ b/src/components/Schedules/Dialog/DescInputBlock.tsx
@@ -9,7 +9,7 @@ interface DescriptionTextProps {
 }
 
 export default function DescInputBlock(props: DescriptionTextProps) {
-	const { description, handleChange } = props;
+	const { description, handleChange, ...textAreaAttrs } = props;
 
 	return (
 		<div className='schedule-input-list'>
@@ -17,7 +17,7 @@ export default function DescInputBlock(props: DescriptionTextProps) {
 				<img src={DescIcon} />
 			</span>
 			<textarea
-				{...props}
+				{...textAreaAttrs}
 				className='schedule-input__textarea'
 				placeholder={'Add description'}
 				onChange={handleChange}

--- a/src/components/Schedules/Dialog/ScheduleDialog.tsx
+++ b/src/components/Schedules/Dialog/ScheduleDialog.tsx
@@ -78,7 +78,7 @@ export default function ScheduleDialog(props: ScheduleDialogProps) {
 		setScheduleProps(setScheduleProps => ({ ...setScheduleProps, title }));
 	}
 
-	const isIdExists = savedSchedules.find(sch => sch.id === scheduleProps.id);
+	const isIdExists = savedSchedules.find(schedule => schedule.id === scheduleProps.id);
 
 	const editSchedule = () => {
 		dispatchSchedules({

--- a/src/components/Schedules/Dialog/ScheduleMainContent.tsx
+++ b/src/components/Schedules/Dialog/ScheduleMainContent.tsx
@@ -1,10 +1,10 @@
-import { ScheduleNames } from '../../../context/global/index.model';
+import { ScheduleTypeNames } from '../../../context/global/index.model';
 import ScheduleTypeSelector from './ScheduleTypeSelector';
 
 interface MainContentProps {
 	title: string;
 	setTitle: (title: string) => void;
-	scheduleType: ScheduleNames | null;
+	scheduleType: ScheduleTypeNames | null;
 }
 
 export default function ScheduleMainContent(props: MainContentProps) {

--- a/src/components/Schedules/Dialog/ScheduleTypeSelector.tsx
+++ b/src/components/Schedules/Dialog/ScheduleTypeSelector.tsx
@@ -1,11 +1,11 @@
 import { useContext } from 'react';
 import GlobalContext from '../../../context/global/GlobalContext';
 import GlobalContextInterface, {
-	ScheduleNames,
+	ScheduleTypeNames,
 } from '../../../context/global/index.model';
 
 interface ScheduleTypeSelectorProps {
-	scheduleType: ScheduleNames | null | undefined;
+	scheduleType: ScheduleTypeNames | null | undefined;
 }
 export default function ScheduleTypeSelector(props: ScheduleTypeSelectorProps) {
 	const { scheduleType } = props;
@@ -14,7 +14,7 @@ export default function ScheduleTypeSelector(props: ScheduleTypeSelectorProps) {
 		setSelectedScheduleType,
 	} = useContext(GlobalContext) as GlobalContextInterface;
 
-	const scheduleTypeClassName = (buttonName: ScheduleNames) => {
+	const scheduleTypeClassName = (buttonName: ScheduleTypeNames) => {
 		return `schedule-type${buttonName === (scheduleType || selectedScheduleType)
 			? '--active' : ''}`;
 	}

--- a/src/components/Schedules/Event/EventBlock.tsx
+++ b/src/components/Schedules/Event/EventBlock.tsx
@@ -14,7 +14,7 @@ import ColorSelection from './ColorSelection';
 import DescInputBlock from '../Dialog/DescInputBlock';
 import CustomInput from '../Dialog/CustomInputs/CustomInput';
 import { ColorOption } from '../../../themes/data';
-import { stringifyDate } from '../../../util/calendar-arrangement';
+import { convertDateUnitsToString } from '../../../util/calendar-arrangement';
 import { DateUnits } from '../../../context/global/index.model';
 
 export default function EventBlock(props: ScheduleEventProps): JSX.Element {
@@ -26,7 +26,7 @@ export default function EventBlock(props: ScheduleEventProps): JSX.Element {
 		calendarId,
 		dateTime,
 	} = eventProps;
-
+	
 	const locationInputProps = {
 		value: location,
 		onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -61,7 +61,7 @@ export default function EventBlock(props: ScheduleEventProps): JSX.Element {
 			...scheduleProps,
 			dateTime: {
 				...scheduleProps.dateTime,
-				date: stringifyDate(selectedDate),
+				date: convertDateUnitsToString(selectedDate),
 			},
 		}));
 	};

--- a/src/components/Schedules/ScheduleHOC.tsx
+++ b/src/components/Schedules/ScheduleHOC.tsx
@@ -14,7 +14,7 @@ export default function withScheduleDialogToggle(Component: any) {
 			isDialogVisible,
 			setIsDialogVisible,
 			linkRef,
-		] = useComponentVisible(false);
+		] = useComponentVisible();
 
 		const dialogProps = {
 			Component: ScheduleTypeList,

--- a/src/components/Schedules/Task/TaskBlock.tsx
+++ b/src/components/Schedules/Task/TaskBlock.tsx
@@ -3,7 +3,7 @@ import {
 	ScheduleTaskProps,
 	Option,
 } from '../index.model';
-import { stringifyDate } from '../../../util/calendar-arrangement';
+import { convertDateUnitsToString } from '../../../util/calendar-arrangement';
 import { DateUnits } from '../../../context/global/index.model';
 
 import '../styles.scss';
@@ -44,7 +44,7 @@ export default function TaskBlock(props: ScheduleTaskProps): JSX.Element {
 			...scheduleProps,
 			dateTime: {
 				...scheduleProps.dateTime,
-				date: stringifyDate(selectedDate),
+				date: convertDateUnitsToString(selectedDate),
 			},
 		}));
 	};

--- a/src/components/Schedules/View/ScheduleView.tsx
+++ b/src/components/Schedules/View/ScheduleView.tsx
@@ -12,7 +12,7 @@ import {
 	dayjsObj,
 	getScheduleTimeOptions,
 	getShortDate,
-	stringifiedDateToObj,
+	convertStringToDateUnits,
 } from '../../../util/calendar-arrangement';
 import useComponentVisible from '../../../hooks/useComponentVisible';
 
@@ -26,7 +26,7 @@ import LocationIcon from '../../../assets/icons/location.png';
 
 import Alert from '../../../lib/Alert/Alert';
 import DataItem from './DataItem';
-import { ScheduleNames, DateTimeInputs } from '../../../context/global/index.model';
+import { ScheduleTypeNames, DateTimeInputs } from '../../../context/global/index.model';
 import { createPortal } from 'react-dom';
 
 interface ScheduleViewProps {
@@ -36,7 +36,7 @@ interface ScheduleViewProps {
 
 interface HoursRangeProps {
 	readonly dateTime: DateTimeInputs;
-	readonly type: ScheduleNames;
+	readonly type: ScheduleTypeNames;
 }
 
 function HoursRange(props: HoursRangeProps) {
@@ -51,7 +51,7 @@ function HoursRange(props: HoursRangeProps) {
 
 function ScheduleTime(props: HoursRangeProps) {
 	const { dateTime } = props;
-	const dateValues = stringifiedDateToObj(dateTime.date);
+	const dateValues = convertStringToDateUnits(dateTime.date);
 	const shortDate = getShortDate(dayjsObj(dateValues));
 	return <>
 		<div>{shortDate}</div>
@@ -68,13 +68,13 @@ export function ScheduleView(props: ScheduleViewProps) {
 		dispatchSchedules,
 		setIsScheduleDialogVisible,
 	} = useContext(GlobalContext) as GlobalContextInterface;
-	const [alertRef, isAlertVisible, setIsAlertVisible] = useComponentVisible(false);
+	const [alertRef, isAlertVisible, setIsAlertVisible] = useComponentVisible();
 	const associatedCalendar = calendarList.find(cal => cal.id === calendarId);
 
 	useEffect(() => {
 		// Set the received schedule props as a selected schedule
-		setSelectedSchedule((sch: ScheduleTypes | null | undefined) => {
-			return sch === null ? scheduleProps : { ...sch, ...scheduleProps };
+		setSelectedSchedule((schedule: ScheduleTypes | null | undefined) => {
+			return schedule === null ? scheduleProps : { ...schedule, ...scheduleProps };
 		});
 		return () => setSelectedSchedule(null);
 	}, []);
@@ -95,13 +95,12 @@ export function ScheduleView(props: ScheduleViewProps) {
 			})
 		}
 	}
-
 	const deleteSchedule = () => {
 		dispatchSchedules({
 			type: UserActionType.REMOVE,
 			payload: scheduleProps.id,
 		})
-		setIsScheduleViewVisible(visible => !visible);
+		setIsScheduleViewVisible(false);
 	}
 
 	return (<>

--- a/src/context/global/StoreProvider.tsx
+++ b/src/context/global/StoreProvider.tsx
@@ -16,13 +16,13 @@ import GlobalContextInterface, {
 	CalendarListActionTypes,
 	CalendarType,
 	ScheduleActionTypes,
-	ScheduleNames,
+	ScheduleTypeNames,
 	ScheduleTypes,
 	SelectedSchedule,
 	UserActionType,
 } from './index.model';
 import { uniqueID } from '../../util/reusable-funcs';
-import { dateToday, stringifyDate } from '../../util/calendar-arrangement';
+import { dateToday, convertDateUnitsToString } from '../../util/calendar-arrangement';
 import {
 	updateLocalStorage,
 	deleteLocalStorage,
@@ -52,10 +52,12 @@ function actionTypes<
 			})];
 			updateLocalStorage(stateName, editedArr);
 			return editedArr;
-		case UserActionType.REMOVE: // action receives id as its payload prop
+		case UserActionType.REMOVE:
 			const reducedArr = [...state.filter((obj: StateType) => {
+				// The action payload is equivalent to id
 				return obj.id !== action.payload;
 			})];
+			
 			reducedArr.length
 				? updateLocalStorage(stateName, reducedArr)
 				: deleteLocalStorage(stateName);
@@ -107,7 +109,7 @@ export default function StoreProvider({ children }: { children: ReactNode }) {
 	);
 	const [selectedSchedule, setSelectedSchedule] = useState<SelectedSchedule>(null);
 	const [selectedDate, setSelectedDate] = useState(dateToday);
-	const [selectedScheduleType, setSelectedScheduleType] = useState<ScheduleNames>('event');
+	const [selectedScheduleType, setSelectedScheduleType] = useState<ScheduleTypeNames>('event');
 	const { position, recordPos } = useCursorPosition();
 
 	// Note: It can be a tag or a type of a schedule
@@ -123,11 +125,11 @@ export default function StoreProvider({ children }: { children: ReactNode }) {
 		scheduleDialogRef,
 		isScheduleDialogVisible,
 		setIsScheduleDialogVisible,
-	] = useComponentVisible(false);
+	] = useComponentVisible();
 
 	// Default values for schedule dialog(task or event)
 	const [defaultDateTime, setDefaultDateTime] = useState({
-		date: stringifyDate(dateToday),
+		date: convertDateUnitsToString(dateToday),
 		time: {
 			start: new Date().getHours(),
 			end: new Date().getHours(),
@@ -146,7 +148,7 @@ export default function StoreProvider({ children }: { children: ReactNode }) {
 	useEffect(() => {
 		setDefaultDateTime(defaultDateTime => ({
 			...defaultDateTime,
-			date: stringifyDate(selectedDate),
+			date: convertDateUnitsToString(selectedDate),
 		}));
 	}, [selectedDate]);
 

--- a/src/context/global/index.model.ts
+++ b/src/context/global/index.model.ts
@@ -45,7 +45,7 @@ export interface DefaultDateTime {
 type OmitScheduleProps
 	= Omit<TaskInterface | EventInterface, 'dateTime' | 'calendarId'>;
 
-export type ScheduleNames = 'task' | 'event';
+export type ScheduleTypeNames = 'task' | 'event';
 export type ScheduleTypes = EventInterface | TaskInterface;
 export type SchedulePayload = EditEvent | EditTask;
 export type ScheduleTypesOnArray = Array<EventInterface> | Array<TaskInterface>
@@ -55,7 +55,7 @@ export interface Schedule {
 	description: string;
 	calendarId: number;
 	dateTime: DateTimeInputs;
-	type: ScheduleNames;
+	type: ScheduleTypeNames;
 }
 export interface EventInterface extends Schedule {
 	location: string;
@@ -130,6 +130,6 @@ export default interface GlobalContextInterface {
 	scheduleDialogRef: RefObject<HTMLElement | null>;
 	isScheduleDialogVisible: boolean;
 	setIsScheduleDialogVisible: Dispatch<SetStateAction<boolean>>;
-	selectedScheduleType: ScheduleNames;
-	setSelectedScheduleType: Dispatch<SetStateAction<ScheduleNames>>;
+	selectedScheduleType: ScheduleTypeNames;
+	setSelectedScheduleType: Dispatch<SetStateAction<ScheduleTypeNames>>;
 }

--- a/src/hooks/useComponentVisible.ts
+++ b/src/hooks/useComponentVisible.ts
@@ -8,12 +8,16 @@ import {
 type ElementsToRef = HTMLDivElement | HTMLElement
 	| HTMLButtonElement;
 
+interface ComponentVisibleHookProps {
+	initialVisibility?: boolean
+}
+
 // A custom hook that controls the visibility 
 // of the referenced component
-function useComponentVisible(initialIsVisible: boolean) {
-	const [isComponentVisible, setIsComponentVisible] = useState(initialIsVisible);
+function useComponentVisible({ initialVisibility = false }:
+	ComponentVisibleHookProps = {}) {
+	const [isComponentVisible, setIsComponentVisible] = useState(initialVisibility);
 	const linkRef = useRef<HTMLButtonElement | null>(null);
-	// HTMLDivElement || React.Ref<typeof React.Component>
 	const componentRef = useRef<HTMLDivElement | null>(null);
 
 	const handleHideDropdown = (e: KeyboardEvent) => {
@@ -30,13 +34,26 @@ function useComponentVisible(initialIsVisible: boolean) {
 		}
 	}
 
+	const isAlertElsClicked = (event: MouseEvent) => {
+		const clickedElement = event.target as HTMLElement;
+		let currentNode: HTMLElement | null = clickedElement;
+		while (currentNode) {
+			if (currentNode.classList.contains('alert')) {
+				return true;
+			}
+			currentNode = currentNode.parentElement;
+		}
+	}
+
 	const handleClickOutside = (event: MouseEvent) => {
-		if (
-			componentRef.current &&
-			handleCurrentTarget(componentRef, event) &&
-			// When it somewhat loses the ref to link, 
-			// it allows to untoggle component anyway
-			(linkRef.current === null || handleCurrentTarget(linkRef, event))) {
+
+		const clickedWithinComponent = componentRef.current &&
+			handleCurrentTarget(componentRef, event);
+		const clickedToggleVisibilityBtn
+			= linkRef.current === null || handleCurrentTarget(linkRef, event);
+
+		if (clickedWithinComponent && !isAlertElsClicked(event)
+			&& clickedToggleVisibilityBtn) {
 			setIsComponentVisible(false);
 		}
 	};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,9 +12,9 @@ const root = ReactDOM.createRoot(
 );
 
 root.render(
-	<React.StrictMode>
-		<StoreProvider>
-			<App />
-		</StoreProvider>
-	</React.StrictMode>,
+	// <React.StrictMode>
+	<StoreProvider>
+		<App />
+	</StoreProvider>,
+	// </React.StrictMode>,
 );

--- a/src/util/calendar-arrangement.ts
+++ b/src/util/calendar-arrangement.ts
@@ -144,7 +144,7 @@ export function getScheduleTimeOptions() {
 }
 
 // Note: it excludes the unit seconds "ss"
-export function stringifyDate(args: DateUnits) {
+export function convertDateUnitsToString(args: DateUnits) {
 	// convert month codes (1 to 12) to zero-indexed (0 to 11)
 	const monthIndex = (args.month as number) - 1;
 	const datePropsToArr: ArrayThreeOrMore<number>
@@ -155,7 +155,7 @@ export function stringifyDate(args: DateUnits) {
 		.slice(0, -9);
 }
 
-export function stringifiedDateToObj(stringifiedDate: string) {
+export function convertStringToDateUnits(stringifiedDate: string) {
 	const year = Number(stringifiedDate.slice(0, 4));
 	const month = Number(stringifiedDate.slice(4, 6));
 	const day = Number(stringifiedDate.slice(6, 8));


### PR DESCRIPTION
There are 3 issues fixed:

**Warning Msg: handleChange not getting recognized as an appropriate attribute in a DOM Element**
The warning that has a message of handleChange not getting recognized is because {...props} is used to distribute its properties to the target element. To fix this. I destructure a ...rest property of "props" to ensure that it is acceptable to spread its properties as attributes of the target element.

**Error: Date value is not matched and wrong when editing an instance of existing schedule object**
Error: Date value error refers to the unmatched values that are expected from the existing schedule since it only happens when editing this schedule. This bug happens because most component and calendar-related features primarily (or overly, unfortunately) rely on a context value called selectedDate which is the highlighted date when the user clicks a day within any calendar component. The reason for this is that this value is being shared upon different files which makes prop-passing to children to be a bad idea. 

If the highlighted date is not the same as the expected date from the existing schedule, it'll always use the selectedDate, no matter what especially when it is being edited. **So, why the value of selectedDate is being used?** When changing the value of the date on the date input of the schedule dialog, it'll always rely to the value of selectedDate since it used to change this value with setState in order to be passed around along other features that may use it, Mini Calendar and Header, for example. This happens when toggling visibility of a mini calendar dialog; responsible for changing the date value. The pieces of a solution for this are the following:
- Added initialDate as a prop to the Mini Calendar component
- Since I want the mini calendar to be displayed within a dialog, I passed the argument to the dialog within componentProps.
- I ensure that it'll never change the date with the selectedDate when the mini calendar is first toggled to be visible.

**Error: The action of deleting a schedule is not working**
This turns out to be a visibility issue where clicking within the alert component which is responsible for executing the delete action untoggles its visibility. This happens because there is a hook function that allows toggle visibility of a target component when clicked outside. Well, <Alert /> is placed outside so this happens. I fixed this issue by preventing a component that contains a className which is simple, but it is a bad practice because it is defined as an exclusion within the hook. Now that I'm currently writing, it emerges to me that I must pass a prop to the hook instead. This is a better method of doing so.


**Other things**
- I renamed some funcs/vars that is bad/vague, along the way.